### PR TITLE
fix(virtual-scroll): Preventing 0 items rendering bug

### DIFF
--- a/src/app/components/ionic-selectable/ionic-selectable-modal.component.html
+++ b/src/app/components/ionic-selectable/ionic-selectable-modal.component.html
@@ -125,7 +125,7 @@
     <ion-infinite-scroll-content></ion-infinite-scroll-content>
   </ion-infinite-scroll>
   <ion-list no-margin
-    *ngIf="selectComponent.hasVirtualScroll && selectComponent._hasFilteredItems"
+    *ngIf="selectComponent.hasVirtualScroll"
     [virtualScroll]="selectComponent._filteredGroups[0].items"
     [approxItemHeight]="selectComponent.virtualScrollApproxItemHeight"
     [approxItemWidth]="selectComponent.virtualScrollApproxItemWidth"


### PR DESCRIPTION
Hello Mr @eakoriakin! I'm thankful for your component, it's great!

I'm dealing with the issue #146 in my app, so I decided to help in this repo. I've found the code that causes the bug in the component.

The Ionic's virtual-scroll directive should not be re-rendered due to a template directive (ngIf in this case) because it can't keep it viewport state internally. The virtual-scroll needs to keep disposed on the template to match the boundaries to render items when new items came.

Thanks again!