### PR TITLE
reacting to native-keyboard input by blurring the searchbar (Issue #123)

### DIFF
--- a/src/app/components/ionic-selectable/ionic-selectable-modal.component.html
+++ b/src/app/components/ionic-selectable/ionic-selectable-modal.component.html
@@ -33,6 +33,7 @@
     <ion-searchbar *ngIf="selectComponent.canSearch" #searchbarComponent
       [(ngModel)]="selectComponent._searchText"
       (ionInput)="selectComponent._filterItems()"
+      (search)="selectComponent._finishSearch($event)"
       [placeholder]="selectComponent.searchPlaceholder"
       [debounce]="selectComponent.searchDebounce">
     </ion-searchbar>

--- a/src/app/components/ionic-selectable/ionic-selectable.component.ts
+++ b/src/app/components/ionic-selectable/ionic-selectable.component.ts
@@ -962,6 +962,16 @@ export class IonicSelectableComponent implements ControlValueAccessor, OnInit, O
     }
   }
 
+  _finishSearch(event) {
+    // Only used to control the searchbar
+    // Search is already done after a given debounce time, no need to search again when the user presses the native devices search-button
+
+    if (event && event.target && event.type == 'search') {
+      // We'll blur the searchbar, so that the device is closing the keyboard automatically
+      event.target.blur();
+    } 
+  }
+
   _isItemDisabled(item: any): boolean {
     if (!this.disabledItems) {
       return;


### PR DESCRIPTION
Hey there,
I've created a fix for my issue (#123, https://github.com/eakoriakin/ionic-selectable/issues/123).

Since the native devices buttons while being focused on the searchbar did nothing until now, I've added a blur to it, so that when a user clicks the native keyboard search button, the focus on the searchbar will be removed and the user can see the full results.

The (search)-field for the ion-searchbar seembs to be documented nowhere, but still works as expected and is the only event triggered by pressing the native keyboards button.

Best Regards!