### PR TITLE
Fix deprecated CSS attribute for Virtual Scroll on Ionic 5

### DIFF
--- a/src/app/components/ionic-selectable/ionic-selectable-modal.component.html
+++ b/src/app/components/ionic-selectable/ionic-selectable-modal.component.html
@@ -122,7 +122,7 @@
     (ionInfinite)="selectComponent._getMoreItems()">
     <ion-infinite-scroll-content></ion-infinite-scroll-content>
   </ion-infinite-scroll>
-  <ion-virtual-scroll no-margin
+  <ion-virtual-scroll class="ion-no-margin"
     *ngIf="selectComponent.hasVirtualScroll && selectComponent._hasFilteredItems"
     [items]="selectComponent._filteredGroups[0].items"
     [headerFn]="selectComponent.virtualScrollHeaderFn"


### PR DESCRIPTION
Virtual Scroll list was still using css attribute `no-margin` (`<ion-virtual-scroll no-margin>`).